### PR TITLE
Fix PORT env var type error

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,5 +88,5 @@ if __name__ == "__main__":
 
 
     app.run(host=os.environ.get("HOST", "0.0.0.0"),
-            port=os.environ.get("PORT", os.environ.get('PORT', 8000)),
+            port=int(os.environ.get("PORT", 8000)),
             access_log=True)


### PR DESCRIPTION
Wraps `PORT` in `int()` — `os.environ.get` returns a string, but Sanic's socket binding requires an integer, causing the `TypeError: 'str' object cannot be interpreted as an integer` crash on startup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJToGvPRaiQ2G5CjwBoDLu)_