### PR TITLE
Fix 404s on all blueprint routes (double-slash prefix)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,10 @@ dnspython = ">=2.7.0"
 
 [dev-packages]
 flake8 = ">=7.0.0"
+pytest = "*"
+pytest-sanic = "*"
+sanic-testing = "*"
+httpx = "==0.28.1"
 
 [requires]
 python_version = "3.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "77db642622dec9995ee849b5be3ccac73cfa9aaae02fe5b7e8c49fcf186bddf7"
+            "sha256": "712fbd63c0db3b747d920c654e36afe940c91b5e65fb81f25b9f629bd07c1e62"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1257,6 +1257,30 @@
         }
     },
     "develop": {
+        "anyio": {
+            "hashes": [
+                "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708",
+                "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.13.0"
+        },
+        "async-generator": {
+            "hashes": [
+                "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b",
+                "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.10"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
+                "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2026.5.20"
+        },
         "flake8": {
             "hashes": [
                 "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e",
@@ -1266,6 +1290,47 @@
             "markers": "python_version >= '3.9'",
             "version": "==7.3.0"
         },
+        "h11": {
+            "hashes": [
+                "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1",
+                "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.16.0"
+        },
+        "httpcore": {
+            "hashes": [
+                "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55",
+                "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.0.9"
+        },
+        "httpx": {
+            "hashes": [
+                "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc",
+                "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==0.28.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2",
+                "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.18"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730",
+                "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.3.0"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
@@ -1273,6 +1338,22 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
+                "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==26.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -1289,6 +1370,107 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==3.4.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
+                "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.20.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9",
+                "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==9.0.3"
+        },
+        "pytest-sanic": {
+            "hashes": [
+                "sha256:79daca07acbc0d9c1f9a1f0c7de7df92e159200e729c75e3a040366ff10a186a",
+                "sha256:a9a11f61dedbc3738c6a4f3d8ec24c42d48e25314ca1696f00782c7a0b3e1f16"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==1.9.1"
+        },
+        "sanic-testing": {
+            "hashes": [
+                "sha256:7591ce537e2a651efb6dc01b458e7e4ea5347f6d91438676774c6f505a124731",
+                "sha256:b1027184735e88230891aa0461fff84093abfa3bff0f4d29c0f78f42e59efada"
+            ],
+            "index": "pypi",
+            "version": "==24.6.0"
+        },
+        "websockets": {
+            "hashes": [
+                "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c",
+                "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a",
+                "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe",
+                "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e",
+                "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec",
+                "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1",
+                "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64",
+                "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3",
+                "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8",
+                "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206",
+                "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3",
+                "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156",
+                "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d",
+                "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9",
+                "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad",
+                "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2",
+                "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03",
+                "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8",
+                "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230",
+                "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8",
+                "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea",
+                "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641",
+                "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957",
+                "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6",
+                "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6",
+                "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5",
+                "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f",
+                "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00",
+                "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e",
+                "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b",
+                "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72",
+                "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39",
+                "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9",
+                "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79",
+                "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0",
+                "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac",
+                "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35",
+                "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0",
+                "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5",
+                "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c",
+                "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8",
+                "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1",
+                "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244",
+                "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3",
+                "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767",
+                "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a",
+                "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d",
+                "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd",
+                "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e",
+                "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944",
+                "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82",
+                "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d",
+                "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4",
+                "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5",
+                "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904",
+                "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde",
+                "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f",
+                "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c",
+                "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89",
+                "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da",
+                "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==16.0"
         }
     }
 }

--- a/hbbackend/api/v1/__init__.py
+++ b/hbbackend/api/v1/__init__.py
@@ -13,5 +13,5 @@ api_v1 = Blueprint.group(
     password_reset_blueprint,
     categories_blueprint,
     transactions_blueprint,
-    url_prefix='/'
+    url_prefix=''
 )

--- a/hbbackend/api/v1/categories/categories.py
+++ b/hbbackend/api/v1/categories/categories.py
@@ -35,7 +35,7 @@ async def get_categories(request):
 
     logger.info(f"Decrypting categories took {data['time_ms']}ms")
 
-    if categories is '':
+    if categories== '':
         return response.json({'error': {"message": 'incorrect password'}},
                              status=422)
 
@@ -81,7 +81,7 @@ async def update_categories(request):
 
     logger.info(f'Decrypting settings took {data["time_ms"]}ms')
 
-    if settings is '':
+    if settings== '':
         return response.json({'error': {"message": 'incorrect password'}},
                              status=422)
 

--- a/hbbackend/api/v1/transactions/transactions.py
+++ b/hbbackend/api/v1/transactions/transactions.py
@@ -35,7 +35,7 @@ async def get_transactions(request):
 
     logger.info(f"Decrypting transactions took {data['time_ms']}ms")
 
-    if transactions is '':
+    if transactions== '':
         return response.json({
             'error': {'message': 'incorrect password'}}, status=422)
 
@@ -69,7 +69,7 @@ async def update_transactions(request):
 
     logger.info(f'Decrypting settings took {data["time_ms"]}ms')
 
-    if settings is '':
+    if settings== '':
         return response.json({'error': {'message': 'incorrect password'}},
                              status=422)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,49 @@
+"""
+Routing smoke tests — verifies OPTIONS preflight routes are reachable
+(regression for the double-slash blueprint prefix bug fixed in Sanic 24+).
+"""
+import pytest
+from sanic import Sanic, response
+from sanic_testing import TestManager
+
+from hbbackend.api.v1 import api_v1
+
+
+@pytest.fixture
+def app():
+    # Use a unique name per test run to avoid Sanic's app-registry collisions
+    test_app = Sanic("test_routing")
+    TestManager(test_app)
+
+    test_app.blueprint(api_v1)
+
+    @test_app.middleware("response")
+    async def cors(request, resp):
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Headers"] = "*"
+
+    return test_app
+
+
+OPTIONS_ROUTES = [
+    "/account/login",
+    "/account/register",
+    "/account/reset-password",
+    "/account/confirm-reset-password",
+    "/account/categories/list",
+    "/account/categories/update",
+    "/account/transactions/list",
+    "/account/transactions/update",
+]
+
+
+@pytest.mark.parametrize("path", OPTIONS_ROUTES)
+def test_options_returns_200(app, path):
+    _, resp = app.test_client.options(path)
+    assert resp.status == 200, f"OPTIONS {path} returned {resp.status}, expected 200"
+
+
+@pytest.mark.parametrize("path", OPTIONS_ROUTES)
+def test_options_cors_headers(app, path):
+    _, resp = app.test_client.options(path)
+    assert "Access-Control-Allow-Origin" in resp.headers


### PR DESCRIPTION
In Sanic 24.x, `Blueprint.group(url_prefix='/')` prepends `/` to each child blueprint's already-slash-prefixed `url_prefix`, producing paths like `//account/categories/list` that never match incoming requests — hence the 404s on all routes.

Changing `url_prefix='/'` → `url_prefix=''` on the group restores the correct paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJToGvPRaiQ2G5CjwBoDLu)_