### PR TITLE
Remove OPTIONS catch-all that conflicts with blueprint routes in Sanic 25.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Install dependencies
+        run: pipenv install --dev --deploy
+
+      - name: Run tests
+        run: pipenv run python -m pytest tests/ -v

--- a/app.py
+++ b/app.py
@@ -82,11 +82,6 @@ if __name__ == "__main__":
         response.headers["Access-Control-Allow-Headers"] = "*"
 
 
-    @app.route('/<path_arg:path>', methods=['OPTIONS'])
-    async def respond_to_options(request, path_arg=''):
-        return response.text('')
-
-
     app.run(host=os.environ.get("HOST", "0.0.0.0"),
             port=int(os.environ.get("PORT", 8000)),
             access_log=True)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,6 +1,7 @@
 """
-Routing smoke tests — verifies OPTIONS preflight routes are reachable
-(regression for the double-slash blueprint prefix bug fixed in Sanic 24+).
+Routing smoke tests — verifies OPTIONS preflight routes are reachable.
+Mirrors the real app setup (blueprint + CORS middleware, no catch-all)
+to catch route registration conflicts.
 """
 import pytest
 from sanic import Sanic, response


### PR DESCRIPTION
In Sanic 25.x, the app-level `OPTIONS /<path_arg:path>` catch-all conflicts with the specific blueprint `@bp.options()` routes, causing those specific routes to return 404. Since every route already has an explicit OPTIONS handler, the catch-all was redundant — removing it fixes the 404s.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJToGvPRaiQ2G5CjwBoDLu)_