### PR TITLE
Handle OPTIONS preflight via request middleware

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,15 +72,25 @@ def setup_commons():
     }
 
 
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+}
+
+
 if __name__ == "__main__":
     setup_commons()
     app.blueprint(api_v1)
 
-    @app.middleware('response')
-    async def cors(request, response):
-        response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Access-Control-Allow-Headers"] = "*"
+    @app.middleware('request')
+    async def handle_options(req):
+        if req.method == 'OPTIONS':
+            return response.empty(headers=CORS_HEADERS)
 
+    @app.middleware('response')
+    async def cors(req, resp):
+        resp.headers.update(CORS_HEADERS)
 
     app.run(host=os.environ.get("HOST", "0.0.0.0"),
             port=int(os.environ.get("PORT", 8000)),

--- a/hbbackend/api/v1/account/login.py
+++ b/hbbackend/api/v1/account/login.py
@@ -52,7 +52,3 @@ async def post(self, request):
         'first_name': user.get('first_name')
     })
 
-
-@bp.options('/login')
-def accept_options(request):
-    return response.text('')

--- a/hbbackend/api/v1/account/password_reset.py
+++ b/hbbackend/api/v1/account/password_reset.py
@@ -82,12 +82,3 @@ async def do_reset_password(request):
             'error': {'message': 'Could not verify details'}
         }, status=422)
 
-
-@bp.options('/confirm-reset-password')
-def accept_options_confirm(request):
-    return response.text('')
-
-
-@bp.options('/reset-password')
-def accept_options(request):
-    return response.text('')

--- a/hbbackend/api/v1/account/register.py
+++ b/hbbackend/api/v1/account/register.py
@@ -42,7 +42,3 @@ async def register(request):
         'id': str(id)
     })
 
-
-@bp.options('/register')
-def accept_options(request):
-    return response.text('')

--- a/hbbackend/api/v1/categories/categories.py
+++ b/hbbackend/api/v1/categories/categories.py
@@ -106,11 +106,3 @@ async def update_categories(request):
     })
 
 
-@bp.options('/list')
-def accept_options_list(request):
-    return response.text('')
-
-
-@bp.options('/update')
-def accept_options_update(request):
-    return response.text('')

--- a/hbbackend/api/v1/transactions/transactions.py
+++ b/hbbackend/api/v1/transactions/transactions.py
@@ -93,12 +93,3 @@ async def update_transactions(request):
         'ok': True
     })
 
-
-@bp.options('/list')
-def accept_options_list(request):
-    return response.text('')
-
-
-@bp.options('/update')
-def accept_options_update(request):
-    return response.text('')

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,7 +1,6 @@
 """
-Routing smoke tests — verifies OPTIONS preflight routes are reachable.
-Mirrors the real app setup (blueprint + CORS middleware, no catch-all)
-to catch route registration conflicts.
+Routing smoke tests — verifies OPTIONS preflight routes return 200 + CORS headers.
+OPTIONS is handled by a request middleware so no per-route handlers are needed.
 """
 import pytest
 from sanic import Sanic, response
@@ -9,19 +8,27 @@ from sanic_testing import TestManager
 
 from hbbackend.api.v1 import api_v1
 
+CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+}
+
 
 @pytest.fixture
 def app():
-    # Use a unique name per test run to avoid Sanic's app-registry collisions
     test_app = Sanic("test_routing")
     TestManager(test_app)
-
     test_app.blueprint(api_v1)
 
+    @test_app.middleware("request")
+    async def handle_options(req):
+        if req.method == "OPTIONS":
+            return response.empty(headers=CORS_HEADERS)
+
     @test_app.middleware("response")
-    async def cors(request, resp):
-        resp.headers["Access-Control-Allow-Origin"] = "*"
-        resp.headers["Access-Control-Allow-Headers"] = "*"
+    async def cors(req, resp):
+        resp.headers.update(CORS_HEADERS)
 
     return test_app
 
@@ -41,10 +48,11 @@ OPTIONS_ROUTES = [
 @pytest.mark.parametrize("path", OPTIONS_ROUTES)
 def test_options_returns_200(app, path):
     _, resp = app.test_client.options(path)
-    assert resp.status == 200, f"OPTIONS {path} returned {resp.status}, expected 200"
+    assert resp.status in (200, 204), f"OPTIONS {path} returned {resp.status}, expected 200 or 204"
 
 
 @pytest.mark.parametrize("path", OPTIONS_ROUTES)
 def test_options_cors_headers(app, path):
     _, resp = app.test_client.options(path)
-    assert "Access-Control-Allow-Origin" in resp.headers
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+    assert resp.headers.get("Access-Control-Allow-Methods") == "GET, POST, OPTIONS"


### PR DESCRIPTION
All previous approaches (catch-all route, individual `@bp.options()` handlers) failed in Sanic 25.x due to routing conflicts or interference. A **request middleware** fires before routing entirely, so OPTIONS preflights are always intercepted and returned with CORS headers regardless of what routes exist — no routing edge cases possible.

Also removes all the now-redundant `@bp.options()` handlers across the codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJToGvPRaiQ2G5CjwBoDLu)_