### PR TITLE
Restore url_prefix='/' on Blueprint.group

### DIFF
--- a/hbbackend/api/v1/__init__.py
+++ b/hbbackend/api/v1/__init__.py
@@ -13,5 +13,5 @@ api_v1 = Blueprint.group(
     password_reset_blueprint,
     categories_blueprint,
     transactions_blueprint,
-    url_prefix=''
+    url_prefix='/'
 )


### PR DESCRIPTION
Restores `url_prefix='/'` on `Blueprint.group`. Removing it caused production routes to not match incoming requests. There is no longer a double-slash conflict because OPTIONS preflights are now handled entirely by a request middleware and don't go through routing at all.

**Verified locally:**
- All 8 routes registered with correct leading `/`
- `OPTIONS /account/categories/list` → 204 + `Access-Control-Allow-Origin: *`
- `OPTIONS /account/transactions/list` → 204 + `Access-Control-Allow-Origin: *`  
- `POST /account/categories/list` → 500 (route found; 500 only because DB not connected in test)
- `POST /account/transactions/list` → 500 (same)
- All 16 tests passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJToGvPRaiQ2G5CjwBoDLu)_